### PR TITLE
Allow hexadecimal and decimal values for numeric arguments (#15)

### DIFF
--- a/tbears/command/command_score.py
+++ b/tbears/command/command_score.py
@@ -22,7 +22,7 @@ import importlib
 from iconcommons.icon_config import IconConfig
 from iconservice.base.address import is_icon_address_valid
 
-from tbears.util.argparse_type import IconAddress, IconPath
+from tbears.util.argparse_type import IconAddress, IconPath, non_negative_num_type
 from tbears.command.command_server import CommandServer
 from tbears.config.tbears_config import FN_CLI_CONF, tbears_cli_config
 from tbears.libs.icon_jsonrpc import IconJsonrpc, IconClient
@@ -50,7 +50,7 @@ class CommandScore(object):
         # IconPath's 'r' argument means 'read file'
         parser.add_argument('-k', '--key-store', type=IconPath('r'), dest='keyStore',
                             help='Keystore file path. Used to generate "from" address and transaction signature')
-        parser.add_argument('-n', '--nid', help='Network ID')
+        parser.add_argument('-n', '--nid', type=non_negative_num_type, help='Network ID')
         parser.add_argument('-c', '--config', type=IconPath(), help=f'deploy config path (default: {FN_CLI_CONF})')
         parser.add_argument('-p', '--password', help='keystore file\'s password', dest='password')
 

--- a/tbears/command/command_wallet.py
+++ b/tbears/command/command_wallet.py
@@ -24,7 +24,7 @@ from tbears.config.tbears_config import FN_CLI_CONF, tbears_cli_config, keystore
 from tbears.libs.icon_jsonrpc import IconClient, IconJsonrpc
 from tbears.tbears_exception import TBearsCommandException
 from tbears.util import jsonrpc_params_to_pep_style
-from tbears.util.argparse_type import IconAddress, IconPath, hash_type
+from tbears.util.argparse_type import IconAddress, IconPath, hash_type, non_negative_num_type
 from tbears.util.keystore_manager import validate_password, make_key_store_content
 
 
@@ -65,7 +65,7 @@ class CommandWallet:
     def _add_blockbyheight_parser(subparsers):
         parser = subparsers.add_parser('blockbyheight', help='Get block info using given block height',
                                        description='Get block info using given block height')
-        parser.add_argument('height', help='height of the block to be queried.')
+        parser.add_argument('height', type=non_negative_num_type, help='height of the block to be queried.')
         parser.add_argument('-u', '--node-uri', dest='uri', help='URI of node (default: http://127.0.0.1:9000/api/v3)')
         parser.add_argument('-c', '--config', type=IconPath(),
                             help=f'Configuration file path. This file defines the default value for '

--- a/tbears/util/argparse_type.py
+++ b/tbears/util/argparse_type.py
@@ -61,9 +61,31 @@ def hash_type(string: str) -> str:
 
 
 def port_type(string: str) -> int:
-    port = int(string, 10)
+    try:
+        port = int(string, 10)
+    except ValueError:
+        raise ArgumentTypeError(f"Invalid integer value '{string}'")
+    except TypeError as e:
+        raise ArgumentTypeError(f'Invalid type. {e}')
 
     if port < 0 or port > 65535:
-        raise ArgumentTypeError(f"Invalid port'{string}'. Port must be 0 < port < 65536")
+        raise ArgumentTypeError(f"Invalid port '{string}'. Port must be 0 < port < 65536")
 
     return port
+
+
+def non_negative_num_type(string: str) -> str:
+    try:
+        value = int(string, 10)
+    except ValueError:
+        try:
+            value = int(string, 16)
+        except ValueError:
+            raise ArgumentTypeError(f"Invalid integer value '{string}'. Hexadecimal and decimal values are allowed")
+    except TypeError as e:
+        raise ArgumentTypeError(f'Invalid type. {e}')
+
+    if value < 0:
+        raise ArgumentTypeError(f"Invalid non-negative number '{value}'")
+
+    return hex(value)

--- a/tests/test_argparse_type.py
+++ b/tests/test_argparse_type.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2018 theloop Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+import unittest
+
+from tbears.util.argparse_type import *
+
+
+class TestArgparseType(unittest.TestCase):
+    @staticmethod
+    def touch(path):
+        with open(path, 'a'):
+            os.utime(path, None)
+
+    def test_icon_path(self):
+        file_path = './icon_path_test'
+
+        # 'r' mode
+        icon_path = IconPath()
+        self.assertRaises(ArgumentTypeError, icon_path, file_path)
+
+        self.touch(file_path)
+        self.assertEqual(icon_path(file_path), file_path)
+
+        # 'w' mode
+        icon_path = IconPath('w')
+        self.assertRaises(ArgumentTypeError, icon_path, file_path)
+
+        os.remove(file_path)
+        self.assertEqual(icon_path(file_path), file_path)
+
+        # 'd' mode
+        icon_path = IconPath('d')
+        dir_path = 'dir_not_exist'
+        self.assertRaises(ArgumentTypeError, icon_path, dir_path)
+
+        dir_path = 'dir_path_test_file'
+        self.touch(dir_path)
+        self.assertRaises(ArgumentTypeError, icon_path, dir_path)
+        os.remove(dir_path)
+
+        dir_path = 'dir_path_test'
+        os.mkdir(dir_path)
+        self.assertEqual(icon_path(dir_path), dir_path)
+        shutil.rmtree(dir_path)
+
+    def test_icon_address(self):
+        icon_addr = IconAddress('all')
+
+        # valid address
+        addr = f'cx{"a"*40}'
+        self.assertEqual(icon_addr(addr), addr)
+        addr = f'hx{"b"*40}'
+        self.assertEqual(icon_addr(addr), addr)
+        addr = f'hx{"0"*40}'
+        self.assertEqual(icon_addr(addr), addr)
+
+        # length < 42
+        self.assertRaises(ArgumentTypeError, icon_addr, f'cx1')
+
+        # length > 42
+        self.assertRaises(ArgumentTypeError, icon_addr, f'cx{"0"*40}1')
+
+        # upper case
+        self.assertRaises(ArgumentTypeError, icon_addr, f'cx{"0"*39}A')
+
+        # None hex
+        self.assertRaises(ArgumentTypeError, icon_addr, f'cx{"0"*39}k')
+
+        # hx prefix
+        icon_addr = IconAddress('hx')
+
+        addr = f'hx{"b"*40}'
+        self.assertEqual(icon_addr(addr), addr)
+
+        self.assertRaises(ArgumentTypeError, icon_addr, f'cx{"b"*40}')
+
+        # cx prefix
+        icon_addr = IconAddress('cx')
+
+        addr = f'cx{"b"*40}'
+        self.assertEqual(icon_addr(addr), addr)
+
+        self.assertRaises(ArgumentTypeError, icon_addr, f'hx{"b"*40}')
+
+    def test_hash_type(self):
+        # valid hash
+        hash_str = f'0x{"b"*64}'
+        self.assertEqual(hash_type(hash_str), hash_str)
+
+        # invalid type
+        hash_str = 0x1234567890123456789012345678901234567890123456789012345678901234
+        self.assertRaises(ArgumentTypeError, hash_type, hash_str)
+
+        # invalid prefix
+        hash_str = f'hx{"b"*64}'
+        self.assertRaises(ArgumentTypeError, hash_type, hash_str)
+
+        # length < 66
+        self.assertRaises(ArgumentTypeError, hash_type, '0x1')
+
+        # length > 66
+        hash_str = f'0x{"b"*64}1'
+        self.assertRaises(ArgumentTypeError, hash_type, hash_str)
+
+        # upper case
+        hash_str = f'0x{"b"*63}B'
+        self.assertRaises(ArgumentTypeError, hash_type, hash_str)
+
+        # None hex
+        hash_str = f'0x{"b"*63}k'
+        self.assertRaises(ArgumentTypeError, hash_type, hash_str)
+
+    def test_port_type(self):
+        # valid port
+        port_str = "9000"
+        self.assertEqual(port_type(port_str), int(port_str, 10))
+
+        # invalid type
+        port_str = 9000
+        self.assertRaises(ArgumentTypeError, port_type, port_str)
+
+        # invalid hex string
+        port_str = '0x1'
+        self.assertRaises(ArgumentTypeError, port_type, port_str)
+
+        # value < 0
+        port_str = '-1'
+        self.assertRaises(ArgumentTypeError, port_type, port_str)
+
+        # value > 65535
+        port_str = '65536'
+        self.assertRaises(ArgumentTypeError, port_type, port_str)
+
+    def test_non_negative_num_type(self):
+        # valid int
+        int_str = "1"
+        self.assertEqual(non_negative_num_type(int_str), hex(int(int_str, 10)))
+        int_str = "1a"
+        self.assertEqual(non_negative_num_type(int_str), hex(int(int_str, 16)))
+        int_str = "0x1a"
+        self.assertEqual(non_negative_num_type(int_str), int_str)
+        int_str = "0"
+        self.assertEqual(non_negative_num_type(int_str), hex(int(int_str, 10)))
+        int_str = "0x0"
+        self.assertEqual(non_negative_num_type(int_str), int_str)
+
+        # invalid type
+        int_str = 9000
+        self.assertRaises(ArgumentTypeError, non_negative_num_type, int_str)
+
+        # invalid hex string
+        int_str = '1k'
+        self.assertRaises(ArgumentTypeError, non_negative_num_type, int_str)
+        int_str = '0x1k'
+        self.assertRaises(ArgumentTypeError, non_negative_num_type, int_str)
+
+        # invalid negative number
+        int_str = "-1"
+        self.assertRaises(ArgumentTypeError, non_negative_num_type, int_str)
+        int_str = "-0x1"
+        self.assertRaises(ArgumentTypeError, non_negative_num_type, int_str)

--- a/tests/test_setting_icon_config.py
+++ b/tests/test_setting_icon_config.py
@@ -199,7 +199,7 @@ class TestCliTestUtil(unittest.TestCase):
         f = ['-f hxaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '']
         o = ['-o cx0000000000000000000000000000000000000000', '']
         k = [f'-k {os.path.join(IN_ICON_CONFIG_TEST_DIRECTORY, "test_cli_config_keystore")}', '']
-        n = ['-n 0x3_user_input', '']
+        n = ['-n 0x3', '']
         c = [f'-c {os.path.join(IN_ICON_CONFIG_TEST_DIRECTORY, "test_tbears_cli_config.json")}']
 
         # deploy
@@ -252,7 +252,7 @@ class TestCliTestUtil(unittest.TestCase):
         u = ['-u http://127.0.0.1:9000/api/v3_user_input', '']
         f = ['-f hxaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '']
         k = [f'-k {os.path.join(IN_ICON_CONFIG_TEST_DIRECTORY, "test_cli_config_keystore")}', '']
-        n = ['-n 0x3_user_input', '']
+        n = ['-n 0x3', '']
         c = [f'-c {os.path.join(IN_ICON_CONFIG_TEST_DIRECTORY, "test_tbears_cli_config.json")}']
 
         # lastblock


### PR DESCRIPTION
- Add non-negative-number type
- Applied to
  'nid' argument of 'deploy' command
  'height' argument of 'blockbyhash' command
- Add unittest test_argparse_type.py