### PR TITLE
Update and synchronize the password validation regexp with the one in ICONex Chrome

### DIFF
--- a/tbears/util/keystore_manager.py
+++ b/tbears/util/keystore_manager.py
@@ -53,4 +53,4 @@ def validate_password(password) -> bool:
     False: When the password is invalid format
     """
 
-    return bool(re.match(r'^(?=.*\d)(?=.*[a-zA-Z])(?=.*[!@#$%^&*()_+{}:<>?]).{8,}$', password))
+    return bool(re.match(r'^(?=.*\d)(?=.*[a-zA-Z])(?=.*[?!:\.,%+-/*<>{}\(\)\[\]`"\'~_^\\|@#$&]).{8,}$', password))


### PR DESCRIPTION
For reference, see https://github.com/icon-project/iconex_chrome_extension/pull/12

I wrote a small python snippet in order to check if the regexp works as expected : 

```python
import re

def validate_password(password):
    return bool(re.match(r'^(?=.*\d)(?=.*[a-zA-Z])(?=.*[?!:\.,%+-/*<>{}\(\)\[\]`"\'~_^\\|@#$&]).{8,}$', password))

specials = "?!:.,%+-/*<>{}()[]`\"'~_^\\|@#$&"
success = True

for special in specials:
    # Check special character at multiple positions
    if (not validate_password (special + "Whatever123")):
        print ("ERROR PREFIX : " + special);
        success = False

    if (not validate_password ("What" + special + "ever123")):
        print ("ERROR MIDDLE : " + special);
        success = False

    if (not validate_password ("Whatever123" + special)):
        print ("ERROR POSTFIX : " + special);
        success = False

if (success):
    print("Success!")
```

![success](https://i.imgur.com/yuf55B3.png)