### PR TITLE
Add -v, --verbose global option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Available commands:
 | shorthand, Name | default | Description                     |
 | --------------- | :------ | ------------------------------- |
 | -h, --help      |         | Show this help message and exit |
-| -v, --verbose   |         | Produce verbose output. For example, running command, configuration and ICON JSON-RPC API request body are printed|
+| -v, --verbose   |         | Verbose mode. Print debugging messages about its progress. |
 
 
 

--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ T-Bears has 20 commands, `init`, `start`, `stop`, `deploy`, `clear`, `test`, `ge
 **Usage**
 
 ```bash
-usage: tbears [-h] [-d] command ...
+usage: tbears [-h] [-v] command ...
 
 tbears v1.1.0 arguments
 
 optional arguments:
   -h, --help     show this help message and exit
-  -d, --debug    Debug mode
+  -v, --verbose  Verbose mode
 
 Available commands:
   If you want to see help message of commands, use "tbears command -h"
@@ -181,8 +181,8 @@ Available commands:
 
 | shorthand, Name | default | Description                     |
 | --------------- | :------ | ------------------------------- |
-| -h, --help      |         | show this help message and exit |
-| -d, --debug     |         | Debug mode                      |
+| -h, --help      |         | Show this help message and exit |
+| -v, --verbose   |         | Produce verbose output. For example, running command, configuration and ICON JSON-RPC API request body are printed|
 
 
 

--- a/tbears/command/command_score.py
+++ b/tbears/command/command_score.py
@@ -20,11 +20,12 @@ import getpass
 import unittest
 
 from iconcommons.icon_config import IconConfig
+from iconcommons.logger import Logger
 from iconservice.base.address import is_icon_address_valid
 
 from tbears.util.argparse_type import IconAddress, IconPath, non_negative_num_type
 from tbears.command.command_server import CommandServer
-from tbears.config.tbears_config import FN_CLI_CONF, tbears_cli_config
+from tbears.config.tbears_config import FN_CLI_CONF, tbears_cli_config, TBEARS_CLI_TAG
 from tbears.libs.icon_jsonrpc import IconJsonrpc, IconClient
 from tbears.tbears_exception import TBearsDeleteTreeException, TBearsCommandException
 
@@ -72,6 +73,8 @@ class CommandScore(object):
 
         # load configurations
         conf = self.get_icon_conf(args.command, args=vars(args))
+
+        Logger.info(f"run the '{args.command}' command with config: {conf}", TBEARS_CLI_TAG)
 
         # run command
         return getattr(self, args.command)(conf)

--- a/tbears/command/command_score.py
+++ b/tbears/command/command_score.py
@@ -74,7 +74,7 @@ class CommandScore(object):
         # load configurations
         conf = self.get_icon_conf(args.command, args=vars(args))
 
-        Logger.info(f"run the '{args.command}' command with config: {conf}", TBEARS_CLI_TAG)
+        Logger.info(f"Run '{args.command}' command with config: {conf}", TBEARS_CLI_TAG)
 
         # run command
         return getattr(self, args.command)(conf)

--- a/tbears/command/command_server.py
+++ b/tbears/command/command_server.py
@@ -63,7 +63,7 @@ class CommandServer(object):
         user_input = vars(args)
         conf = self.get_icon_conf(args.command, args=user_input)
 
-        Logger.info(f"run the '{args.command}' command with config: {conf}", TBEARS_CLI_TAG)
+        Logger.info(f"Run '{args.command}' command with config: {conf}", TBEARS_CLI_TAG)
 
         # run command
         return getattr(self, args.command)(conf)

--- a/tbears/command/command_server.py
+++ b/tbears/command/command_server.py
@@ -28,13 +28,12 @@ from iconcommons.logger import Logger
 from tbears.tbears_exception import TBearsCommandException, TBearsWriteFileException
 from tbears.util import write_file
 from tbears.util.argparse_type import port_type, IconPath
-from tbears.config.tbears_config import FN_SERVER_CONF, tbears_server_config, ConfigKey
+from tbears.config.tbears_config import FN_SERVER_CONF, tbears_server_config, ConfigKey, TBEARS_CLI_TAG
 from tbears.block_manager.block_manager import TBEARS_BLOCK_MANAGER
 
 
 BLOCKMANAGER_MODULE_NAME = 'tbears.block_manager'
 TBEARS_CLI_ENV = '/tmp/.tbears.env'
-TBEARS_CLI_TAG = 'tbears_cli'
 
 
 class CommandServer(object):
@@ -63,6 +62,8 @@ class CommandServer(object):
         # load configurations
         user_input = vars(args)
         conf = self.get_icon_conf(args.command, args=user_input)
+
+        Logger.info(f"run the '{args.command}' command with config: {conf}", TBEARS_CLI_TAG)
 
         # run command
         return getattr(self, args.command)(conf)

--- a/tbears/command/command_util.py
+++ b/tbears/command/command_util.py
@@ -69,7 +69,7 @@ class CommandUtil(object):
             print(f"Wrong command {args.command}")
             return
 
-        Logger.info(f"run the '{args.command}' command", TBEARS_CLI_TAG)
+        Logger.info(f"Run '{args.command}' command", TBEARS_CLI_TAG)
 
         # run command
         return getattr(self, args.command)(vars(args))

--- a/tbears/command/command_util.py
+++ b/tbears/command/command_util.py
@@ -16,13 +16,16 @@ import json
 import os
 
 import IPython
+from iconcommons.logger.logger import Logger
 
+from tbears.config.tbears_config import (
+    FN_SERVER_CONF, FN_CLI_CONF, tbears_server_config, tbears_cli_config, make_server_config, FN_KEYSTORE_TEST1,
+    keystore_test1, TBEARS_CLI_TAG
+)
 from tbears.tbears_exception import TBearsCommandException
 from tbears.util import (
     get_score_template, get_package_json_dict, write_file, PROJECT_ROOT_PATH
 )
-from tbears.config.tbears_config import FN_SERVER_CONF, FN_CLI_CONF, tbears_server_config, tbears_cli_config,\
-    make_server_config, FN_KEYSTORE_TEST1, keystore_test1
 from tbears.util.argparse_type import IconPath
 
 
@@ -65,6 +68,8 @@ class CommandUtil(object):
         if not hasattr(self, args.command):
             print(f"Wrong command {args.command}")
             return
+
+        Logger.info(f"run the '{args.command}' command", TBEARS_CLI_TAG)
 
         # run command
         return getattr(self, args.command)(vars(args))

--- a/tbears/command/command_wallet.py
+++ b/tbears/command/command_wallet.py
@@ -19,8 +19,9 @@ import os
 
 from iconservice.base.address import is_icon_address_valid
 from iconcommons import IconConfig
+from iconcommons.logger.logger import Logger
 
-from tbears.config.tbears_config import FN_CLI_CONF, tbears_cli_config, keystore_test1
+from tbears.config.tbears_config import FN_CLI_CONF, tbears_cli_config, keystore_test1, TBEARS_CLI_TAG
 from tbears.libs.icon_jsonrpc import IconClient, IconJsonrpc
 from tbears.tbears_exception import TBearsCommandException
 from tbears.util import jsonrpc_params_to_pep_style
@@ -476,6 +477,8 @@ class CommandWallet:
 
         user_input = vars(args)
         conf = self.get_icon_conf(args.command, args= user_input)
+
+        Logger.info(f"run the '{args.command}' command with config: {conf}", TBEARS_CLI_TAG)
 
         # run command
         return getattr(self, args.command)(conf)

--- a/tbears/command/command_wallet.py
+++ b/tbears/command/command_wallet.py
@@ -478,7 +478,7 @@ class CommandWallet:
         user_input = vars(args)
         conf = self.get_icon_conf(args.command, args= user_input)
 
-        Logger.info(f"run the '{args.command}' command with config: {conf}", TBEARS_CLI_TAG)
+        Logger.info(f"Run '{args.command}' command with config: {conf}", TBEARS_CLI_TAG)
 
         # run command
         return getattr(self, args.command)(conf)

--- a/tbears/config/tbears_config.py
+++ b/tbears/config/tbears_config.py
@@ -18,6 +18,8 @@ from copy import deepcopy
 FN_SERVER_CONF = './tbears_server_config.json'
 FN_CLI_CONF = './tbears_cli_config.json'
 
+TBEARS_CLI_TAG = 'tbears_cli'
+
 
 class ConfigKey:
     CHANNEL = 'channel'

--- a/tbears/libs/icon_jsonrpc.py
+++ b/tbears/libs/icon_jsonrpc.py
@@ -21,7 +21,9 @@ import itertools
 import hashlib
 
 from secp256k1 import PrivateKey
+from iconcommons.logger.logger import Logger
 
+from tbears.config.tbears_config import TBEARS_CLI_TAG
 from tbears.libs.icx_signer import key_from_key_store, IcxSigner
 from tbears.libs.in_memory_zip import InMemoryZip
 from tbears.libs.icon_serializer import generate_origin_for_icx_send_tx_hash
@@ -448,6 +450,8 @@ class IconClient(object):
         :param request: JSON-RPC request
         :return: response dictionary of request.
         """
+        Logger.info(f"Send request to {self.__uri}. Request body: {request}", TBEARS_CLI_TAG)
+
         # if query doesn't change any state of iconservice or loopchain, use 'send' method
         response = requests.post(url=self.__uri, json=request)
         try:


### PR DESCRIPTION
Produce verbose output. For example, running command, configuration and ICON JSON-RPC API request body are printed