### PR TITLE
Modify the main file path of check_project method

### DIFF
--- a/tbears/command/command_score.py
+++ b/tbears/command/command_score.py
@@ -256,7 +256,8 @@ def check_project(project_path: str) -> int:
                 raise TBearsCommandException(f'package.json has wrong format.')
 
             # there is no main_file
-            if not os.path.exists(f"{project_path}/{package['main_file']}.py"):
-                raise TBearsCommandException(f"There is no main_file '{project_path}/{package['main_file']}.py'")
+            main_file_path = '/'.join(package['main_file'].split('.'))
+            if not os.path.exists(f"{project_path}/{main_file_path}.py"):
+                raise TBearsCommandException(f"There is no main_file '{project_path}/{main_file_path}.py'")
 
     return 0


### PR DESCRIPTION
If the main_file of score is in a subdirectory, 

In `package.json`, we will write the location of main_file as follows:

// package.json

```json
{
    "version": "0.0.1",
    "main_file": "sub_dir.main_file_name",
    "main_score": "Mainscore"
}
```

When deploying in `t-bears` in this state, the following error occurs.

> There is no main_file 'score/sub_dir.main_file_name.py'

Here is the section to check the main_file before deploying.

It check the file using the value of `main_file` as it is.

// command_score.py

```python
# there is no main_file
if not os.path.exists(f"{project_path}/{package['main_file']}.py"):
    raise TBearsCommandException(f"There is no main_file '{project_path}/{package['main_file']}.py'")
```

When checking for file with main_file value, change '.' to '/' and then check the file check, it seems to be able to deploy without problem.

```python
# there is no main_file
main_file_path = '/'.join(package['main_file'].split('.'))
if not os.path.exists(f"{project_path}/{main_file_path}.py"):
    raise TBearsCommandException(f"There is no main_file '{project_path}/{main_file_path}.py'")
```

