### PR TITLE
IS-460: Fix import failure for modified iconservice exceptions

### DIFF
--- a/tbears/libs/scoretest/patch/score_patcher.py
+++ b/tbears/libs/scoretest/patch/score_patcher.py
@@ -147,6 +147,7 @@ class ScorePatcher:
         mock_context.configure_mock(event_log_stack=context.event_log_stack)
         mock_context.configure_mock(traces=context.traces)
         mock_context.configure_mock(icon_score_mapper=context.icon_score_mapper)
+        ContextGetter._context = mock_context
 
     @staticmethod
     def patch_score_methods(score):


### PR DESCRIPTION
1. Fix import failure for modified iconservice exceptions.
2. Modify the readonly property of the context since the implementation of _is_db_writable_on_context has changed.
3. Set context to Writable context when normal method called.