### PR TITLE
IS-1125-getting-context-method-returns-none-in-score-unit-test 

### DIFF
--- a/tbears/libs/scoretest/mock/db.py
+++ b/tbears/libs/scoretest/mock/db.py
@@ -57,7 +57,7 @@ class PlyvelDB(object):
             del self._db[bytes_key]
 
     def close(self) -> None:
-        self._db = None
+        self._db.clear()
 
     def get_sub_db(self, key: bytes):
         return PlyvelDB(self.make_db())

--- a/tbears/libs/scoretest/patch/context.py
+++ b/tbears/libs/scoretest/patch/context.py
@@ -21,9 +21,11 @@ from iconservice.base.exception import InvalidParamsException
 from iconservice.base.message import Message
 from iconservice.base.transaction import Transaction
 from iconservice.icon_constant import IconScoreContextType, IconScoreFuncType
-from iconservice.iconscore.icon_score_context import IconScoreContext, ContextGetter
+from iconservice.iconscore.icon_score_context import IconScoreContext
 
 from ..mock.block import Block
+from ..mock.db import MockKeyValueDatabase
+from ..mock.icx_engine import IcxEngine
 from ....libs.icon_integrate_test import create_tx_hash
 
 if TYPE_CHECKING:
@@ -31,6 +33,9 @@ if TYPE_CHECKING:
 
 score_mapper = {}
 interface_score_mapper = {}
+MAIN_NET_REVISION = 8
+context_db = MockKeyValueDatabase.create_db()  # Patch SCORE to use dictionary DB instance of LEVEL DB
+IcxEngine.db = context_db
 
 
 def get_icon_score(address: 'Address'):
@@ -47,32 +52,35 @@ def get_icon_score(address: 'Address'):
 
 
 def get_default_context():
-    context = IconScoreContext()
-    block = Block()
-    context.block = block
-    context.icon_score_mapper = score_mapper
-    context.traces = []
-    context.validate_score_blacklist = Mock(return_value=True)
-    context.tx = Transaction()
-    context.msg = Message()
-    context.get_icon_score = get_icon_score
-    context.block_batch = None
-    context.tx_batch = None
-    return context
+    mock_context = Mock(spec=IconScoreContext)
+    mock_context.configure_mock(msg=Message())
+    mock_context.configure_mock(tx=Transaction())
+    mock_context.configure_mock(block=Block())
+    mock_context.configure_mock(step_counter=None)
+    mock_context.configure_mock(type=IconScoreContextType.QUERY)
+    mock_context.configure_mock(func_type=IconScoreFuncType.WRITABLE)
+    mock_context.configure_mock(current_address=None)
+    mock_context.configure_mock(block_batch=None)
+    mock_context.configure_mock(tx_batch=None)
+    mock_context.configure_mock(event_logs=None)
+    mock_context.configure_mock(event_log_stack=[])
+    mock_context.configure_mock(traces=[])
+    mock_context.configure_mock(icon_score_mapper=score_mapper)
+    mock_context.configure_mock(revision=MAIN_NET_REVISION)
+    mock_context.icon_score_mapper = score_mapper
+    mock_context.validate_score_blacklist = Mock(return_value=True)
+    mock_context.get_icon_score = get_icon_score
+    return mock_context
+
+
+def clear_data():
+    IcxEngine.db.close()
+    score_mapper.clear()
+    interface_score_mapper.clear()
 
 
 class Context:
     context = get_default_context()
-
-    @classmethod
-    def initialize_variables(cls, sender: Optional['Address']=None, value: int=0, tx_timestamp: Optional[int]=None,
-                             block_height: int=0, func_type: 'IconScoreFuncType'=IconScoreFuncType.READONLY,
-                             context_type: 'IconScoreContextType'=IconScoreContextType.QUERY):
-        cls._set_block(cls.context, block_height)
-        cls._set_msg(cls.context, sender, value)
-        cls._set_tx(cls.context, sender, tx_timestamp, None, 0, 0)
-        cls._set_func_type(cls.context, func_type)
-        cls._set_context_type(cls.context, context_type)
 
     @classmethod
     def get_context(cls):
@@ -94,19 +102,19 @@ class Context:
         context.func_type = IconScoreFuncType.READONLY
 
     @classmethod
-    def set_msg(cls, sender: Optional['Address']=None, value: int=0):
-        context = cls.context = ContextGetter._context
+    def set_msg(cls, sender: Optional['Address'] = None, value: int = 0):
+        context = cls.context
         cls._set_msg(context, sender, value)
 
     @classmethod
-    def set_tx(cls, origin: Optional['Address']=None, timestamp: Optional[int]=None, _hash: Optional[bytes]=None,
-               index: int=0, nonce: int=0):
-        context = cls.context = ContextGetter._context
+    def set_tx(cls, origin: Optional['Address'] = None, timestamp: Optional[int] = None, _hash: Optional[bytes] = None,
+               index: int = 0, nonce: int = 0):
+        context = cls.context
         cls._set_tx(context, origin, timestamp, _hash, index, nonce)
 
     @classmethod
-    def set_block(cls, height: int=0, timestamp: Optional[int]=None):
-        context = cls.context = ContextGetter._context
+    def set_block(cls, height: int = 0, timestamp: Optional[int] = None):
+        context = cls.context
         cls._set_block(context, height, timestamp)
 
     @staticmethod
@@ -131,12 +139,3 @@ class Context:
         block._height = height
         if timestamp:
             block.timestamp = timestamp
-
-    @staticmethod
-    def _set_func_type(context: 'IconScoreContext', func_type: 'IconScoreFuncType'=IconScoreFuncType.WRITABLE):
-        context.func_type = func_type
-
-    @staticmethod
-    def _set_context_type(context: 'IconScoreContext',
-                          context_type: 'IconScoreContextType'=IconScoreContextType.INVOKE):
-        context.type = context_type

--- a/tests/simpleScore2/simpleScore2.py
+++ b/tests/simpleScore2/simpleScore2.py
@@ -14,6 +14,8 @@ class SimpleScore2(IconScoreBase):
     def __init__(self, db: IconScoreDatabase) -> None:
         super().__init__(db)
         self.value = VarDB("value1", db, value_type=str)
+        self.array = ArrayDB("arrayDB", db, value_type=int)
+        self.dict = DictDB("dictDB", db, value_type=int)
         self.score_address = VarDB("score_address", db, value_type=Address)
 
     @eventlog(indexed=0)
@@ -56,8 +58,40 @@ class SimpleScore2(IconScoreBase):
     @external(readonly=True)
     def getSCOREValue2(self) -> str:
         ret = self.call(self.score_address.get(), "getValue", {})
-
         return ret
+
+    @external
+    def appendValue(self, value: int):
+        self.array.put(value)
+
+    @external(readonly=True)
+    def arrayLength(self) -> int:
+        return len(self.array)
+
+    @external
+    def arraySetItem(self, index: int, value: int):
+        self.array[index] = value
+
+    @external(readonly=True)
+    def arrayGetItem(self, index: int) -> int:
+        return self.array[index]
+
+    @external(readonly=True)
+    def arraySum(self) -> int:
+        # written for testing __iter__
+        return sum(self.array)
+
+    @external
+    def dictSetItem(self, key: int, value: int):
+        self.dict[key] = value
+
+    @external(readonly=True)
+    def dictGetItem(self, key: int) -> int:
+        return self.dict[key]
+
+    @external(readonly=True)
+    def dictContains(self, key: int) -> int:
+        return key in self.dict
 
     @external(readonly=True)
     def write_on_readonly(self) -> str:
@@ -90,7 +124,7 @@ class SimpleScore2(IconScoreBase):
 
     @external
     def send(self, to: Address):
-        print(self.icx.send(to, self.msg.value))
+        self.icx.send(to, self.msg.value)
 
     @external
     def get_owner(self) -> Address:

--- a/tests/simpleScore2/tests/test_unit_simpleScore2.py
+++ b/tests/simpleScore2/tests/test_unit_simpleScore2.py
@@ -36,6 +36,24 @@ class TestSimple(ScoreTestCase):
 
         self.assertEqual(self.score2.getValue(), str_value)
 
+    def test_array(self):
+        self.assertEqual(0, self.score2.arrayLength())
+        for v in range(10):
+            self.score2.appendValue(v)
+        self.assertEqual(10, self.score2.arrayLength())
+        self.assertEqual(sum(range(10)), self.score2.arraySum())
+
+        self.score2.arraySetItem(3, 45)
+        self.assertEqual(45, self.score2.arrayGetItem(3))
+
+    def test_dict(self):
+        for v in range(10):
+            self.score2.dictSetItem(v, v+10)
+
+        for v in range(10):
+            self.assertTrue(self.score2.dictContains(v))
+            self.assertEqual(v+10, self.score2.dictGetItem(v))
+
     # try writing value inside readonly method
     def test_write_on_readonly(self):
         self.assertRaises(DatabaseException, self.score2.write_on_readonly)


### PR DESCRIPTION
Patch ContextContainer in SCORE unit-test

* patch ContextContainer._get_context rather than ContextGetter._context in SCORE unittest since ContextGetter._context uses ContextContainer._get_context
* stop patch in ScoreTestCase.tearDownClass so that ScoreTestCase can stop patches even some of test case have failed
* remove useless methods
* add some SCORE unit test for check ArrayDB, DictDB, VarDB work well in SCORE unittest