### PR TITLE
Is-1105: update score test frameworks due to iconservice patched

### DIFF
--- a/tbears/libs/scoretest/patch/context.py
+++ b/tbears/libs/scoretest/patch/context.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 score_mapper = {}
 interface_score_mapper = {}
+icon_network_value = {}
 
 
 def get_icon_score(address: 'Address'):

--- a/tbears/libs/scoretest/patch/context.py
+++ b/tbears/libs/scoretest/patch/context.py
@@ -21,7 +21,8 @@ from iconservice.base.exception import InvalidParamsException
 from iconservice.base.message import Message
 from iconservice.base.transaction import Transaction
 from iconservice.icon_constant import IconScoreContextType, IconScoreFuncType
-from iconservice.iconscore.icon_score_context import IconScoreContext, ContextGetter
+from iconservice.iconscore.icon_score_context import IconScoreContext
+from iconservice.iconscore.context.context import ContextGetter
 
 from ..mock.block import Block
 from ....libs.icon_integrate_test import create_tx_hash
@@ -65,9 +66,10 @@ class Context:
     context = get_default_context()
 
     @classmethod
-    def initialize_variables(cls, sender: Optional['Address']=None, value: int=0, tx_timestamp: Optional[int]=None,
-                             block_height: int=0, func_type: 'IconScoreFuncType'=IconScoreFuncType.READONLY,
-                             context_type: 'IconScoreContextType'=IconScoreContextType.QUERY):
+    def initialize_variables(cls, sender: Optional['Address'] = None, value: int = 0,
+                             tx_timestamp: Optional[int] = None, block_height: int = 0,
+                             func_type: 'IconScoreFuncType' = IconScoreFuncType.READONLY,
+                             context_type: 'IconScoreContextType' = IconScoreContextType.QUERY):
         cls._set_block(cls.context, block_height)
         cls._set_msg(cls.context, sender, value)
         cls._set_tx(cls.context, sender, tx_timestamp, None, 0, 0)
@@ -94,13 +96,13 @@ class Context:
         context.func_type = IconScoreFuncType.READONLY
 
     @classmethod
-    def set_msg(cls, sender: Optional['Address']=None, value: int=0):
+    def set_msg(cls, sender: Optional['Address'] = None, value: int = 0):
         context = cls.context = ContextGetter._context
         cls._set_msg(context, sender, value)
 
     @classmethod
-    def set_tx(cls, origin: Optional['Address']=None, timestamp: Optional[int]=None, _hash: Optional[bytes]=None,
-               index: int=0, nonce: int=0):
+    def set_tx(cls, origin: Optional['Address'] = None, timestamp: Optional[int] = None, _hash: Optional[bytes] = None,
+               index: int = 0, nonce: int = 0):
         context = cls.context = ContextGetter._context
         cls._set_tx(context, origin, timestamp, _hash, index, nonce)
 
@@ -133,10 +135,10 @@ class Context:
             block.timestamp = timestamp
 
     @staticmethod
-    def _set_func_type(context: 'IconScoreContext', func_type: 'IconScoreFuncType'=IconScoreFuncType.WRITABLE):
+    def _set_func_type(context: 'IconScoreContext', func_type: 'IconScoreFuncType' = IconScoreFuncType.WRITABLE):
         context.func_type = func_type
 
     @staticmethod
     def _set_context_type(context: 'IconScoreContext',
-                          context_type: 'IconScoreContextType'=IconScoreContextType.INVOKE):
+                          context_type: 'IconScoreContextType' = IconScoreContextType.INVOKE):
         context.type = context_type

--- a/tbears/libs/scoretest/patch/score_patcher.py
+++ b/tbears/libs/scoretest/patch/score_patcher.py
@@ -27,9 +27,10 @@ from iconservice.base.address import Address, AddressPrefix
 from iconservice.base.exception import InvalidPayableException, InvalidInterfaceException, InvalidRequestException
 from iconservice.database.db import IconScoreDatabase
 from iconservice.icon_constant import IconScoreFuncType, IconScoreContextType
+from iconservice.iconscore.context.context import ContextGetter
 from iconservice.iconscore.icon_score_base2 import _create_address_with_key, _recover_key
 from iconservice.iconscore.icon_score_constant import CONST_BIT_FLAG, ConstBitFlag, FORMAT_IS_NOT_DERIVED_OF_OBJECT
-from iconservice.iconscore.icon_score_context import IconScoreContext, ContextGetter
+from iconservice.iconscore.icon_score_context import IconScoreContext
 from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from iconservice.iconscore.icx import Icx
 
@@ -270,7 +271,7 @@ class ScorePatcher:
         global context_db
         context_db = MockKeyValueDatabase.create_db()
         IcxEngine.db = context_db
-        patch('iconservice.iconscore.icon_score_context.ContextGetter._context').start()
+        patch('iconservice.iconscore.context.context.ContextGetter._context').start()
         patch.object(Icx, "get_balance", side_effect=hooking_get_balance).start()
         patch.object(Icx, "transfer", side_effect=hooking_transfer).start()
         patch.object(IconScoreContextUtil, "get_owner",

--- a/tbears/libs/scoretest/patch/score_patcher.py
+++ b/tbears/libs/scoretest/patch/score_patcher.py
@@ -23,7 +23,7 @@ from inspect import getmembers, isfunction
 from typing import Optional, Any, Dict
 from unittest.mock import Mock, patch
 
-from iconservice import InterfaceScore, IconNetworkValueType
+from iconservice import InterfaceScore
 from iconservice.base.address import Address, AddressPrefix
 from iconservice.base.exception import InvalidPayableException, InvalidInterfaceException, InvalidRequestException
 from iconservice.database.db import IconScoreDatabase
@@ -34,6 +34,7 @@ from iconservice.iconscore.icon_score_constant import CONST_BIT_FLAG, ConstBitFl
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from iconservice.iconscore.icx import Icx
+from iconservice.iconscore.system import IconNetworkValueType
 from iconservice.utils import is_builtin_score
 
 from .context import Context, score_mapper, interface_score_mapper, icon_network_value

--- a/tbears/libs/scoretest/score_test_case.py
+++ b/tbears/libs/scoretest/score_test_case.py
@@ -20,7 +20,7 @@ from unittest.mock import Mock
 from iconservice import IconScoreBase
 from iconservice.base.address import Address
 from iconservice.base.exception import InvalidRequestException
-from iconservice.iconscore.icon_score_context import ContextGetter
+from iconservice.iconscore.context.context import ContextGetter
 
 from .mock.icx_engine import IcxEngine
 from .patch.context import Context, get_icon_score
@@ -52,16 +52,18 @@ class ScoreTestCase(TestCase):
         ScorePatcher.stop_patches()
 
     @staticmethod
-    def get_score_instance(score_class: Type[T], owner: 'Address', on_install_params: dict = {}) -> T:
+    def get_score_instance(score_class: Type[T], owner: 'Address', on_install_params: dict = {},
+                           score_address: Optional[Address] = None) -> T:
         """Get an instance of the SCORE class passed as an score_class arguments
 
         :param score_class: SCORE class to instantiate
         :param owner: Address to set as owner of SCORE
         :param on_install_params: To be passed to the SCORE on_install method
+        :param score_address: score address
         :return: Initialized SCORE
         """
         validate_score(score_class)
-        score_db = ScorePatcher.get_score_db()
+        score_db = ScorePatcher.get_score_db(score_address)
         score = ScorePatcher.initialize_score(score_class, score_db, owner)
         setattr(score, "call", Mock())
         score.on_install(**on_install_params)

--- a/tbears/libs/scoretest/score_test_case.py
+++ b/tbears/libs/scoretest/score_test_case.py
@@ -13,14 +13,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import TypeVar, Type, Optional
+from typing import TypeVar, Type, Optional, List
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from iconservice import IconScoreBase
 from iconservice.base.address import Address
 from iconservice.base.exception import InvalidRequestException
 from iconservice.iconscore.context.context import ContextGetter
+from iconservice.iconscore.icon_score_base2 import PRepInfo
 
 from .mock.icx_engine import IcxEngine
 from .patch.context import Context, get_icon_score
@@ -200,3 +201,11 @@ class ScoreTestCase(TestCase):
         """
         for account, amount in accounts_info.items():
             IcxEngine.db.put(None, account.to_bytes(), amount)
+
+    @staticmethod
+    def patch_main_preps(module: str, prep_info_list: List[PRepInfo]):
+        patch(f"{module}.get_main_prep_info", return_value=(prep_info_list, int)).start()
+
+    @staticmethod
+    def patch_sub_preps(module: str, prep_info_list: List[PRepInfo]):
+        patch(f"{module}.get_main_prep_info", return_value=(prep_info_list, int)).start()

--- a/tbears/libs/scoretest/score_test_case.py
+++ b/tbears/libs/scoretest/score_test_case.py
@@ -35,6 +35,11 @@ def validate_score(score):
         raise InvalidRequestException(f"{score.__name__} is invalid SCORE class")
 
 
+def validate_score_instance(score):
+    if isinstance(score, IconScoreBase) is False:
+        raise InvalidRequestException(f"{score.__name__} is invalid SCORE")
+
+
 class ScoreTestCase(TestCase):
 
     def setUp(self):
@@ -203,9 +208,19 @@ class ScoreTestCase(TestCase):
             IcxEngine.db.put(None, account.to_bytes(), amount)
 
     @staticmethod
-    def patch_main_preps(module: str, prep_info_list: List[PRepInfo]):
-        patch(f"{module}.get_main_prep_info", return_value=(prep_info_list, int)).start()
+    def patch_main_preps(score, prep_info_list: List[PRepInfo], term_end_block: int):
+        validate_score_instance(score)
+        patch(f"{score.__module__}.get_main_prep_info", return_value=(prep_info_list, term_end_block)).start()
 
     @staticmethod
-    def patch_sub_preps(module: str, prep_info_list: List[PRepInfo]):
-        patch(f"{module}.get_main_prep_info", return_value=(prep_info_list, int)).start()
+    def patch_sub_preps(score, prep_info_list: List[PRepInfo], term_end_block: int):
+        validate_score_instance(score)
+        patch(f"{score.__module__}.get_sub_prep_info", return_value=(prep_info_list, term_end_block)).start()
+
+    @staticmethod
+    def create_preps_info(prep_count: int):
+        preps = []
+        for index in range(prep_count):
+            PRepInfo(create_address(), 0, f"PREP{index}")
+            preps.append(PRepInfo)
+        return preps


### PR DESCRIPTION
update score test frameworks due to iconservice patched

- update patching object path
- enable input SCORE address when initializing SCORE in SCORE unit test