### PR TITLE
IS-1239: Fix getting SCORE methods

### DIFF
--- a/tbears/libs/scoretest/patch/context.py
+++ b/tbears/libs/scoretest/patch/context.py
@@ -96,11 +96,13 @@ class Context:
         context.type = IconScoreContextType.INVOKE
         context.event_logs = []
         context.func_type = IconScoreFuncType.WRITABLE
+        context.readonly = False
 
     @staticmethod
     def _set_query_context(context):
         context.type = IconScoreContextType.QUERY
         context.func_type = IconScoreFuncType.READONLY
+        context.readonly = True
 
     @classmethod
     def set_msg(cls, sender: Optional['Address'] = None, value: int = 0):

--- a/tbears/libs/scoretest/patch/context.py
+++ b/tbears/libs/scoretest/patch/context.py
@@ -71,6 +71,7 @@ def get_default_context():
     mock_context.icon_score_mapper = score_mapper
     mock_context.validate_score_blacklist = Mock(return_value=True)
     mock_context.get_icon_score = get_icon_score
+    mock_context.method_flag_trace = []
     return mock_context
 
 

--- a/tbears/libs/scoretest/patch/score_patcher.py
+++ b/tbears/libs/scoretest/patch/score_patcher.py
@@ -110,7 +110,7 @@ def patch_score_method(method):
             if not (method_flag & ScoreFlag.PAYABLE) and context.msg.value > 0:
                 raise InvalidPayableException(f"This method is not payable")
 
-        if method_flag & ScoreFlag.READONLY == ScoreFlag.READONLY:
+        if method_flag & ScoreFlag.READONLY:
             Context._set_query_context(context)
         elif method_flag is not ScoreFlag.NONE or method_name in ("on_install", "on_update"):
             Context._set_invoke_context(context)
@@ -118,8 +118,10 @@ def patch_score_method(method):
             IcxEngine.transfer(context, context.msg.sender, context.current_address, context.msg.value)
 
         result = method(*args, **kwargs)
-        # set context to `invoke context` after method called(for general method. general method can write value)
-        Context._set_invoke_context(context)
+        if method_flag & ScoreFlag.READONLY:
+            # set context to `invoke context` after readonly method called
+            # for general method. general method can write value
+            Context._set_invoke_context(context)
         return result
 
     return patched

--- a/tbears/libs/scoretest/patch/score_patcher.py
+++ b/tbears/libs/scoretest/patch/score_patcher.py
@@ -116,7 +116,7 @@ def patch_score_method(method):
             Context._set_query_context(context)
         else:
             Context._set_invoke_context(context)
-        if bottom_method_flag & ScoreFlag.PAYABLE:
+        if bottom_method_flag & ScoreFlag.PAYABLE and len(context.method_flag_trace) is 0:
             IcxEngine.transfer(context, context.msg.sender, context.current_address, context.msg.value)
 
         context.method_flag_trace.append(method_flag)

--- a/tests/simpleScore2/simpleScore2.py
+++ b/tests/simpleScore2/simpleScore2.py
@@ -38,7 +38,7 @@ class SimpleScore2(IconScoreBase):
 
     @external
     def setValue(self, value: str):
-        self.value.set(value)
+        self._setValue(value)
 
         self.SetValue(value)
 
@@ -95,7 +95,7 @@ class SimpleScore2(IconScoreBase):
 
     @external(readonly=True)
     def write_on_readonly(self) -> str:
-        self.value.set('3')
+        self._setValue('3')
         return 'd'
 
     # This method is for understanding the ScoreTestCase.set_msg method.
@@ -133,3 +133,6 @@ class SimpleScore2(IconScoreBase):
     @external
     def simple_json_dumps(self) -> str:
         return json_dumps({"simple": "value"})
+
+    def _setValue(self, value: str):
+        self.value.set(value)

--- a/tests/simpleScore2/simpleScore2.py
+++ b/tests/simpleScore2/simpleScore2.py
@@ -141,3 +141,22 @@ class SimpleScore2(IconScoreBase):
         value = self.getValue()
         self.setValue(value * 2)
         return value
+
+    @payable
+    def donate(self):
+        pass
+
+    @payable
+    def call_donate_payable(self):
+        self.donate()
+
+    def call_donate(self):
+        self.donate()
+
+    @external
+    def call_donate_external(self):
+        self.donate()
+
+    @external(readonly=True)
+    def call_donate_readonly(self):
+        self.donate()

--- a/tests/simpleScore2/simpleScore2.py
+++ b/tests/simpleScore2/simpleScore2.py
@@ -136,3 +136,8 @@ class SimpleScore2(IconScoreBase):
 
     def _setValue(self, value: str):
         self.value.set(value)
+
+    def general_method(self) -> str:
+        value = self.getValue()
+        self.setValue(value * 2)
+        return value

--- a/tests/simpleScore2/tests/test_unit_simpleScore2.py
+++ b/tests/simpleScore2/tests/test_unit_simpleScore2.py
@@ -175,3 +175,34 @@ class TestSimple(ScoreTestCase):
         self.score2.setValue("value")
         self.score2.general_method()
         self.assertEqual("value"*2, self.score2.getValue())
+
+    def test_payable(self):
+        score2_balance = self.get_balance(self.score2.address)
+        self.assertEqual(score2_balance, 0)
+        donation_value = 10**20
+        self.set_msg(self.test_account3, donation_value)
+        self.score2.donate()
+        score2_balance = self.get_balance(self.score2.address)
+        self.assertEqual(score2_balance, donation_value)
+
+    def test_call_payable_in_none_payable(self):
+        score2_balance = self.get_balance(self.score2.address)
+        self.assertEqual(score2_balance, 0)
+        donation_value = 10**20
+
+        self.set_msg(self.test_account3, donation_value)
+        self.score2.call_donate()
+        score2_balance = self.get_balance(self.score2.address)
+        self.assertEqual(score2_balance, 0)
+
+        self.score2.call_donate_external()
+        score2_balance = self.get_balance(self.score2.address)
+        self.assertEqual(score2_balance, 0)
+
+        self.score2.call_donate_readonly()
+        score2_balance = self.get_balance(self.score2.address)
+        self.assertEqual(score2_balance, 0)
+
+        self.score2.call_donate_payable()
+        score2_balance = self.get_balance(self.score2.address)
+        self.assertEqual(score2_balance, donation_value)

--- a/tests/simpleScore2/tests/test_unit_simpleScore2.py
+++ b/tests/simpleScore2/tests/test_unit_simpleScore2.py
@@ -203,6 +203,11 @@ class TestSimple(ScoreTestCase):
         score2_balance = self.get_balance(self.score2.address)
         self.assertEqual(score2_balance, 0)
 
+    def test_call_payable_in_payable(self):
+        # transfer icx only once
+        donation_value = 10**20
+        self.set_msg(self.test_account3, donation_value)
+
         self.score2.call_donate_payable()
         score2_balance = self.get_balance(self.score2.address)
         self.assertEqual(score2_balance, donation_value)

--- a/tests/simpleScore2/tests/test_unit_simpleScore2.py
+++ b/tests/simpleScore2/tests/test_unit_simpleScore2.py
@@ -169,3 +169,9 @@ class TestSimple(ScoreTestCase):
         self.assertEqual(self.score2.getValue(), 'value')
         self.score2._setValue('value2')
         self.assertEqual(self.score2.getValue(), 'value2')
+
+    def test_general_method(self):
+        # test for context properly set after readonly method called
+        self.score2.setValue("value")
+        self.score2.general_method()
+        self.assertEqual("value"*2, self.score2.getValue())

--- a/tests/simpleScore2/tests/test_unit_simpleScore2.py
+++ b/tests/simpleScore2/tests/test_unit_simpleScore2.py
@@ -164,3 +164,8 @@ class TestSimple(ScoreTestCase):
         self.set_msg(self.test_account1, 123123)
         self.score2.send(self.test_account3)
 
+    def test_put_on_general_method(self):
+        self.score2._setValue('value')
+        self.assertEqual(self.score2.getValue(), 'value')
+        self.score2._setValue('value2')
+        self.assertEqual(self.score2.getValue(), 'value2')


### PR DESCRIPTION
* fix the way of getting SCORE methods
  - do not set context to invoke context forcibly before general method called
  - set context to `invoke context` after method called(for general method. general method can write value) 
* add unit test write DB in general method